### PR TITLE
PILOT-6806: Display error message instead of authentication error modal

### DIFF
--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -7,8 +7,15 @@ use Aacotroneo\Saml2\Saml2Auth;
 use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use HL7, Auth;
-use App\Exceptions\HL7\{InvalidMessageHL7Exception,InvalidHL7SegmentException, MissingHL7OrganizationException,
-    MissingHL7SpecialtyException, MissingHL7ChiefComplaintException, MissingHL7WorkupChecklistException};
+use App\Exceptions\HL7\{
+    InvalidMessageHL7Exception,
+    InvalidHL7SegmentException,
+    MissingHL7OrganizationException,
+    MissingHL7SpecialtyException,
+    MissingHL7ChiefComplaintException,
+    MissingHL7WorkupChecklistException,
+    NoPermissionHL7Exception
+};
 use App\Exceptions\AccessExceptions\PermissionDeniedException;
 
 
@@ -203,6 +210,10 @@ class Saml2Controller extends Controller
             return $this->processError( $e->getMessage() );
         }
         catch( MissingHL7WorkupChecklistException $e )
+        {
+            return $this->processError( $e->getMessage() );
+        }
+        catch( NoPermissionHL7Exception $e )
         {
             return $this->processError( $e->getMessage() );
         }


### PR DESCRIPTION
This is ready for code review.

A new exception was added: `NoPermissionHL7Exception`